### PR TITLE
Fix crash of build.py on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ local_settings.py
 db.sqlite3
 db.sqlite3-journal
 .vscode/
+.idea/
 static/
 
 /config/settings/.env

--- a/miq/management/commands/build.py
+++ b/miq/management/commands/build.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
             return
 
         self.stdout.write('Building client app ...')
-        subprocess.run(['npm', 'run', 'build'], cwd=client_dir)
+        subprocess.run(['npm', 'run', 'build'], cwd=client_dir, shell=True)
 
         self.stdout.write('Collecting static files ...')
         call_command(


### PR DESCRIPTION
Fix crash of `build.py` command on Windows. Unable to find npm repository if `subprocess.run()` is not callled with `shell=True` argument.

Add .idea/ folder to .gitignore for people on PyCharm.